### PR TITLE
Allow lower case step decorators

### DIFF
--- a/lib/step-jumper.coffee
+++ b/lib/step-jumper.coffee
@@ -8,7 +8,7 @@ module.exports =
         @restOfLine = matchData[2]
 
     stepTypeRegex: ->
-      new RegExp "@(Given|When|Then|And)\(.*\)"
+      new RegExp "@(Given|When|Then|And)\(.*\)", "i"
 
     extractStepDescriptor: (@line) ->
       step_descriptor = @line.match(/\(\'([^\']*)/)


### PR DESCRIPTION
Step definitions with lower case decorators were not recognized. The documentation uses lower case decorators: http://pythonhosted.org/behave/api.html#step-functions

Now both lower and upper case decorators are recognized.